### PR TITLE
Replace compute alpha APIs with beta  APIs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -36,7 +36,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"golang.org/x/oauth2/google"
-	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/option"
@@ -308,9 +308,9 @@ func fetchClients(ctx context.Context, basePath string, authedClient *http.Clien
 		return nil, err
 	}
 
-	// Retry for up-to 5 minutes for Compute Alpha API calls.
-	alphaOpt := getRetryableClientOption(5, 5*time.Second, 160*time.Second, authedClient)
-	computeServiceAlpha, err := computealpha.NewService(ctx, alphaOpt)
+	// Retry for up-to 5 minutes for Compute Beta API calls.
+	betaOpt := getRetryableClientOption(5, 5*time.Second, 160*time.Second, authedClient)
+	computeServiceBeta, err := computebeta.NewService(ctx, betaOpt)
 	if err != nil {
 		return nil, err
 	}
@@ -321,7 +321,7 @@ func fetchClients(ctx context.Context, basePath string, authedClient *http.Clien
 	return &pkg.Clients{
 		Compute: &pkg.Compute{
 			V1:    computeService,
-			Alpha: computeServiceAlpha,
+			Beta: computeServiceBeta,
 		},
 		Container: &pkg.Container{V1: containerService},
 	}, nil

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"regexp"
 
-	computealpha "google.golang.org/api/compute/v0.alpha"
+	computebeta "google.golang.org/api/compute/v0.beta"
 	"google.golang.org/api/compute/v1"
 	"google.golang.org/api/container/v1"
 	"google.golang.org/api/googleapi"
@@ -103,7 +103,7 @@ type ContainerService interface {
 
 type Compute struct {
 	V1    *compute.Service
-	Alpha *computealpha.Service
+	Beta *computebeta.Service
 }
 
 func (c *Compute) GetInstanceGroupManager(ctx context.Context, project, location, instanceGroupManager string, opts ...googleapi.CallOption) (*compute.InstanceGroupManager, error) {
@@ -117,9 +117,9 @@ func (c *Compute) GetInstanceTemplate(ctx context.Context, project, instanceTemp
 	return c.V1.InstanceTemplates.Get(project, instanceTemplate).Context(ctx).Do(opts...)
 }
 
-// SwitchToCustomMode transparently uses computealpha.Service.SwitchToCustomMode.
+// SwitchToCustomMode transparently uses computebeta.Service.SwitchToCustomMode.
 func (c *Compute) SwitchToCustomMode(ctx context.Context, project, name string, opts ...googleapi.CallOption) (*compute.Operation, error) {
-	resp, err := c.Alpha.Networks.SwitchToCustomMode(project, name).Context(ctx).Do(opts...)
+	resp, err := c.Beta.Networks.SwitchToCustomMode(project, name).Context(ctx).Do(opts...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This script was using gcloud compute alpha APIs which are not currently available to all users, and there is no mention on how to apply for access on the docs for [converting legacy networks containing GKE clusters](https://cloud.google.com/vpc/docs/using-legacy#convert-network-gke).

Replacing the alpha dependencies with the beta ones seems to be working just fine. Also note that the [current docs on how to migrate a legacy network](https://cloud.google.com/vpc/docs/using-legacy#convert) are already suggesting to use  `gcloud beta compute` rather than `gcloud alpha compute`.

